### PR TITLE
Fix minor compiler warnings

### DIFF
--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -42,7 +42,7 @@ fn parse_params() -> Params {
 }
 
 /// Create Signal generator based on given params
-fn create_generator(params: &Params) -> Box<SignalGen + 'static> {
+fn create_generator(params: &Params) -> Box<dyn SignalGen + 'static> {
     match params.gen_name.as_ref() {
         "triangle"  => Box::new(TriangleGen::new(params.freq)),
         "square"    => Box::new(SquareGen::new(params.freq)),

--- a/examples/spectrum.rs
+++ b/examples/spectrum.rs
@@ -47,7 +47,7 @@ fn parse_params() -> Params {
 }
 
 /// Create Signal generator based on given params
-fn create_generator(params: &Params) -> Box<SignalGen + 'static> {
+fn create_generator(params: &Params) -> Box<dyn SignalGen + 'static> {
     match params.gen_name.as_ref() {
         "triangle"  => Box::new(TriangleGen::new(params.freq)),
         "square"    => Box::new(SquareGen::new(params.freq)),

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -6,11 +6,11 @@ use crate::{ComplexBuffer, RealBuffer, ProcessingNode};
 
 
 pub struct ForwardFFT {
-    fft: Arc<FFT<f32>>,
+    fft: Arc<dyn FFT<f32>>,
 }
 
 pub struct InverseFFT {
-    fft: Arc<FFT<f32>>,
+    fft: Arc<dyn FFT<f32>>,
 }
 
 impl ForwardFFT {
@@ -50,7 +50,7 @@ impl InverseFFT {
 
 
 pub struct ForwardFFTNode {
-    fft: Arc<FFT<f32>>,
+    fft: Arc<dyn FFT<f32>>,
     input_complex: ComplexBuffer,
     output: ComplexBuffer,
 }
@@ -81,7 +81,7 @@ impl ProcessingNode for ForwardFFTNode {
 
 
 pub struct InverseFFTNode {
-    fft: Arc<FFT<f32>>,
+    fft: Arc<dyn FFT<f32>>,
     input_complex: ComplexBuffer,
     output_complex: ComplexBuffer,
     output: RealBuffer,
@@ -107,7 +107,7 @@ impl ProcessingNode for InverseFFTNode {
         for i in 0..n {
             self.input_complex[i] = input[i];
         }
-        self.fft.process(&mut self.input_complex, &mut self.output_complex);;
+        self.fft.process(&mut self.input_complex, &mut self.output_complex);
         for i in 0..n {
             self.output[i] = self.output_complex[i].re;
         }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -267,14 +267,14 @@ impl SignalGen for ChirpGen {
 
 /// Create Source node based on generator
 pub struct GenNode {
-    gen: Box<SignalGen>,
+    gen: Box<dyn SignalGen>,
     output: RealBuffer,
     sample_freq: f32,
     current_sample: f32,
 }
 
 impl GenNode {
-    pub fn new(gen: Box<SignalGen>, sample_freq: f32, buffer_size: usize) -> GenNode {
+    pub fn new(gen: Box<dyn SignalGen>, sample_freq: f32, buffer_size: usize) -> GenNode {
         GenNode { gen, output: vec![0.0; buffer_size], sample_freq, current_sample: 0.0 }
     }
 }


### PR DESCRIPTION
Most of these are related to requiring `dyn` for on trait objects. One double semicolon.